### PR TITLE
Error "RESERVED BITS" in "fail.txt"

### DIFF
--- a/interface/interface/hal/TARGET_NXP/TARGET_LPC11U35/DAP_config.h
+++ b/interface/interface/hal/TARGET_NXP/TARGET_LPC11U35/DAP_config.h
@@ -112,15 +112,29 @@ Provides definitions about:
 #define TDI_PIN										16
 #define SWO_TDO_PORT							0
 #define SWO_TDO_PIN								23
-#define RESET_PORT								1
-#define RESET_PIN									19
+#ifdef IDAP_PROTO
 #define TRST_PORT									0
 #define TRST_PIN									22
+#define RESET_PORT								1
+#define RESET_PIN									19
+#else
+#define TRST_PORT									0
+#define TRST_PIN									20
+#define RESET_PORT								0
+#define RESET_PIN									17
+#endif
 
+#ifdef IDAP_PROTO
 #define LED_CON_PORT		0
-#define LED_CON_PIN			17		// LED1 Red Connect
+#define LED_CON_PIN			17		// LED1 Red
 #define LED_RUN_PORT		1
-#define LED_RUN_PIN			15		// LED2 Green Run
+#define LED_RUN_PIN			15		// LED2 Green
+#else
+#define LED_CON_PORT		0
+#define LED_CON_PIN			9		// LED1 Red
+#define LED_RUN_PORT		0
+#define LED_RUN_PIN			8		// LED2 Green
+#endif
 
 
 //**************************************************************************************************

--- a/interface/interface/hal/TARGET_NXP/TARGET_LPC11U35/DAP_config.h
+++ b/interface/interface/hal/TARGET_NXP/TARGET_LPC11U35/DAP_config.h
@@ -1,27 +1,37 @@
-/* CMSIS-DAP Interface Firmware
- * Copyright (c) 2009-2013 ARM Limited
+/**************************************************************************//**
+ * @file     DAP_config.h
+ * @brief    CMSIS-DAP Configuration File (Template)
+ * @version  V1.00
+ * @date     31. May 2012
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * @note
+ * Copyright (C) 2012 ARM Limited. All rights reserved.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * @note
+ * modifed 2 Jan 2015 for IDAP-Link
+ * Copyright (C) 2015 I-SYST inc. All rights reserved.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
 
 
 //**************************************************************************************************
-/**
+/** 
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
-\ingroup DAP_ConfigIO_gr
+\ingroup DAP_ConfigIO_gr 
 @{
 Provides definitions about:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
@@ -30,31 +40,18 @@ Provides definitions about:
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
-#include "LPC11Uxx.h"                            // Debug Unit Cortex-M Processor Header File
-
-// Board configuration options
-
-// Configure nReset as open drain
-#if defined(BOARD_UBLOX_C027)
-#define CONF_OPENDRAIN
-#endif
-
-// Configure JTAG option
-#if defined(BOARD_BAMBINO_210) || defined(BOARD_BAMBINO_210E)
-// LPC43xx multicore targets require JTAG to debug slave cores
-#define CONF_JTAG
-#endif
+#include "LPC11Uxx.h"                             // Debug Unit Cortex-M Processor Header File
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000       ///< Specifies the CPU Clock in Hz
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
 /// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
-/// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
-/// required.
+/// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be 
+/// requrired.
 #define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
@@ -63,15 +60,11 @@ Provides definitions about:
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#if defined(CONF_JTAG)
-#define DAP_JTAG                1               ///< JTAG Mode: 1 = available
-#else
-#define DAP_JTAG                0               ///< JTAG Mode: 0 = not available
-#endif
+#define DAP_JTAG                0               ///< JTAG Mode: 1 = available, 0 = not available.
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        4               ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
@@ -80,7 +73,7 @@ Provides definitions about:
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   5000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   1000000         ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
 /// This configuration settings is used to optimized the communication performance with the
@@ -91,7 +84,8 @@ Provides definitions about:
 /// This configuration settings is used to optimized the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
 /// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        1              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+#define DAP_PACKET_COUNT        4              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -100,59 +94,43 @@ Provides definitions about:
 #define TARGET_DEVICE_FIXED     0               ///< Target Device: 1 = known, 0 = unknown;
 
 #if TARGET_DEVICE_FIXED
-#define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
-#define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
+#define TARGET_DEVICE_VENDOR    "ARM"          ///< String indicating the Silicon Vendor
+#define TARGET_DEVICE_NAME      "Cortex-M4"    ///< String indicating the Target Device
 #endif
 
 ///@}
 
+// IDAP-Link SWJ pin maps
 
-// Peripheral register bit masks (used for pin inits)
-#define FUNC_0					0
-#define FUNC_1					1
-#define PULL_DOWN_ENABLED		(1 << 3)
-#define PULL_UP_ENABLED			(2 << 3)
-#define OPENDRAIN				(1 << 10)
+#define SWDIO_TMS_DIRCTRL_PORT		0
+#define SWDIO_TMS_DIRCTRL_PIN			12
+#define SWDIO_TMS_PORT						0
+#define SWDIO_TMS_PIN							13
+#define SWCLK_TCK_PORT						0
+#define SWCLK_TCK_PIN							14
+#define TDI_PORT									0
+#define TDI_PIN										16
+#define SWO_TDO_PORT							0
+#define SWO_TDO_PIN								23
+#define RESET_PORT								1
+#define RESET_PIN									19
+#define TRST_PORT									0
+#define TRST_PIN									22
 
-// Debug Port I/O Pins
-// For LPC11Uxx DAPs all SWD and JTAG pins are on GPIO port 0
-// Default is mbed HDK reference design with LPC11U35/501
-// SWCLK/TCK Pin                PIO0_7
-#define PIN_SWCLK_IN_BIT        7
-#define PIN_SWCLK               (1 << PIN_SWCLK_IN_BIT)
-#define PIN_SWCLK_TCK_IOCON     LPC_IOCON->PIO0_7
+#define LED_CON_PORT		0
+#define LED_CON_PIN			17		// LED1 Red Connect
+#define LED_RUN_PORT		1
+#define LED_RUN_PIN			15		// LED2 Green Run
 
-// SWDIO/TMS In/Out Pin         PIO0_8
-#define PIN_SWDIO_IN_BIT        8
-#define PIN_SWDIO               (1 << PIN_SWDIO_IN_BIT)
-#define PIN_SWDIO_TMS_IOCON     LPC_IOCON->PIO0_8
-
-// nRESET Pin                   PIO0_2
-#define PIN_nRESET_IN_BIT       2
-#define PIN_nRESET              (1 << PIN_nRESET_IN_BIT)
-#define PIN_nRESET_IOCON        LPC_IOCON->PIO0_2
-
-#if (DAP_JTAG != 0)
-
-// TDI Pin                      PIO0_17
-#define PIN_TDI_IN_BIT          17
-#define PIN_TDI                 (1 << PIN_TDI_IN_BIT)
-#define PIN_TDI_IOCON           LPC_IOCON->PIO0_17
-
-// SWO/TDO Pin                  PIO0_9
-#define PIN_TDO_IN_BIT          9
-#define PIN_TDO                 (1 << PIN_TDO_IN_BIT)
-#define PIN_TDO_IOCON           LPC_IOCON->PIO0_9
-#endif // (DAP_JTAG != 0)
 
 //**************************************************************************************************
-/**
+/** 
 \defgroup DAP_Config_PortIO_gr CMSIS-DAP Hardware I/O Pin Access
-\ingroup DAP_ConfigIO_gr
+\ingroup DAP_ConfigIO_gr 
 @{
 
 Standard I/O Pins of the CMSIS-DAP Hardware Debug Port support standard JTAG mode
-and Serial Wire Debug (SWD) mode. In SWD mode only 2 pins are required to implement the debug
+and Serial Wire Debug (SWD) mode. In SWD mode only 2 pins are required to implement the debug 
 interface of a device. The following I/O Pins are provided:
 
 JTAG I/O Pin                 | SWD I/O Pin          | CMSIS-DAP Hardware pin mode
@@ -160,19 +138,19 @@ JTAG I/O Pin                 | SWD I/O Pin          | CMSIS-DAP Hardware pin mod
 TCK: Test Clock              | SWCLK: Clock         | Output Push/Pull
 TMS: Test Mode Select        | SWDIO: Data I/O      | Output Push/Pull; Input (for receiving data)
 TDI: Test Data Input         |                      | Output Push/Pull
-TDO: Test Data Output        |                      | Input
+TDO: Test Data Output        |                      | Input             
 nTRST: Test Reset (optional) |                      | Output Open Drain with pull-up resistor
 nRESET: Device Reset         | nRESET: Device Reset | Output Open Drain with pull-up resistor
 
 
 DAP Hardware I/O Pin Access Functions
 -------------------------------------
-The various I/O Pins are accessed by functions that implement the Read, Write, Set, or Clear to
-these I/O Pins.
+The various I/O Pins are accessed by functions that implement the Read, Write, Set, or Clear to 
+these I/O Pins. 
 
 For the SWDIO I/O Pin there are additional functions that are called in SWD I/O mode only.
-This functions are provided to achieve faster I/O that is possible with some advanced GPIO
-peripherals that can independently write/read a single I/O pin without affecting any other pins
+This functions are provided to achieve faster I/O that is possible with some advanced GPIO 
+peripherals that can independently write/read a single I/O pin without affecting any other pins 
 of the same I/O port. The following SWDIO I/O Pin functions are provided:
  - \ref PIN_SWDIO_OUT_ENABLE to enable the output mode from the DAP hardware.
  - \ref PIN_SWDIO_OUT_DISABLE to enable the input mode to the DAP hardware.
@@ -187,32 +165,30 @@ of the same I/O port. The following SWDIO I/O Pin functions are provided:
 Configures the DAP Hardware I/O pins for JTAG mode:
  - TCK, TMS, TDI, nTRST, nRESET to output mode and set to high level.
  - TDO to input mode.
-*/
+*/ 
 static __inline void PORT_JTAG_SETUP (void) {
-#if (DAP_JTAG != 0)
-    LPC_GPIO->SET[0]  =  PIN_TDI;
-    LPC_GPIO->DIR[0] |=  PIN_TDI;
-    LPC_GPIO->DIR[0] &= ~PIN_TDO;
-#endif
+	LPC_GPIO->SET[SWCLK_TCK_PORT] = (1 << SWCLK_TCK_PIN);
+	LPC_GPIO->SET[SWDIO_TMS_DIRCTRL_PORT] = (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_GPIO->SET[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] |= (1 << SWDIO_TMS_PORT);
+	LPC_GPIO->SET[TDI_PORT] = (1 << TDI_PIN);
+	LPC_GPIO->SET[TRST_PORT] = (1 << TRST_PIN);
+	LPC_GPIO->SET[RESET_PORT] = (1 << RESET_PIN);
 }
  
 /** Setup SWD I/O pins: SWCLK, SWDIO, and nRESET.
 Configures the DAP Hardware I/O pins for Serial Wire Debug (SWD) mode:
  - SWCLK, SWDIO, nRESET to output mode and set to default high level.
  - TDI, TMS, nTRST to HighZ mode (pins are unused in SWD mode).
-*/
+*/ 
 static __inline void PORT_SWD_SETUP (void) {
-    LPC_GPIO->SET[0] = PIN_SWCLK;
-    LPC_GPIO->SET[0] = PIN_SWDIO;
-#if defined(CONF_OPENDRAIN)
-    // open drain logic
-    LPC_GPIO->DIR[0] &= ~PIN_nRESET;
-    LPC_GPIO->CLR[0]  =  PIN_nRESET; 
-    LPC_GPIO->DIR[0] |= (PIN_SWCLK | PIN_SWDIO);
-#else
-    LPC_GPIO->SET[0] = PIN_nRESET;
-    LPC_GPIO->DIR[0]  |= (PIN_SWCLK | PIN_SWDIO | PIN_nRESET);
-#endif
+	LPC_GPIO->SET[SWCLK_TCK_PORT] = (1 << SWCLK_TCK_PIN);
+	LPC_GPIO->SET[SWDIO_TMS_DIRCTRL_PORT] = (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_GPIO->SET[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] |= (1 << SWDIO_TMS_PORT);
+	LPC_GPIO->SET[RESET_PORT] = (1 << RESET_PIN);
+	LPC_GPIO->CLR[TDI_PORT] = (1 << TDI_PIN);
+	LPC_GPIO->CLR[TRST_PORT] = (1 << TRST_PIN);
 }
 
 /** Disable JTAG/SWD I/O Pins.
@@ -220,17 +196,13 @@ Disables the DAP Hardware I/O pins which configures:
  - TCK/SWCLK, TMS/SWDIO, TDI, TDO, nTRST, nRESET to High-Z mode.
 */
 static __inline void PORT_OFF (void) {
-    LPC_GPIO->CLR[0] = PIN_SWCLK;
-    LPC_GPIO->CLR[0] = PIN_SWDIO;
-#if defined(CONF_OPENDRAIN)
-    // open drain logic
-    LPC_GPIO->DIR[0] &= ~PIN_nRESET; // reset not an output
-    LPC_GPIO->CLR[0]  =  PIN_nRESET;
-    LPC_GPIO->DIR[0] |= (PIN_SWCLK | PIN_SWDIO); 
-#else
-    LPC_GPIO->SET[0] = PIN_nRESET;
-    LPC_GPIO->DIR[0] |= (PIN_SWCLK | PIN_SWDIO | PIN_nRESET);
-#endif
+	LPC_GPIO->CLR[SWCLK_TCK_PORT] = (1 << SWCLK_TCK_PIN);
+	LPC_GPIO->CLR[SWDIO_TMS_DIRCTRL_PORT] = (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_GPIO->CLR[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] |= (1 << SWDIO_TMS_PORT);
+	LPC_GPIO->CLR[TDI_PORT] = (1 << TDI_PIN);
+	LPC_GPIO->DIR[TRST_PORT] &= ~(1 << TRST_PIN);
+	LPC_GPIO->DIR[RESET_PORT] &= ~(1 << RESET_PIN);
 }
 
 
@@ -240,21 +212,21 @@ static __inline void PORT_OFF (void) {
 \return Current status of the SWCLK/TCK DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_SWCLK_TCK_IN  (void) {
-    return LPC_GPIO->B[PIN_SWCLK_IN_BIT] & 0x1;
+  return (LPC_GPIO->B[SWCLK_TCK_PIN]);
 }
 
 /** SWCLK/TCK I/O pin: Set Output to High.
 Set the SWCLK/TCK DAP hardware I/O pin to high level.
 */
 static __forceinline void     PIN_SWCLK_TCK_SET (void) {
-    LPC_GPIO->SET[0] = (PIN_SWCLK);
+	LPC_GPIO->SET[SWCLK_TCK_PORT] = (1 << SWCLK_TCK_PIN);
 }
 
 /** SWCLK/TCK I/O pin: Set Output to Low.
 Set the SWCLK/TCK DAP hardware I/O pin to low level.
 */
 static __forceinline void     PIN_SWCLK_TCK_CLR (void) {
-    LPC_GPIO->CLR[0] = (PIN_SWCLK);
+	LPC_GPIO->CLR[SWCLK_TCK_PORT] = (1 << SWCLK_TCK_PIN);
 }
 
 
@@ -264,38 +236,38 @@ static __forceinline void     PIN_SWCLK_TCK_CLR (void) {
 \return Current status of the SWDIO/TMS DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_SWDIO_TMS_IN  (void) {
-    return LPC_GPIO->B[PIN_SWDIO_IN_BIT] & 0x1;
+  return (LPC_GPIO->B[SWDIO_TMS_PIN]);
 }
 
 /** SWDIO/TMS I/O pin: Set Output to High.
 Set the SWDIO/TMS DAP hardware I/O pin to high level.
 */
 static __forceinline void     PIN_SWDIO_TMS_SET (void) {
-    LPC_GPIO->SET[0] = (PIN_SWDIO);
+	LPC_GPIO->SET[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
 }
 
 /** SWDIO/TMS I/O pin: Set Output to Low.
 Set the SWDIO/TMS DAP hardware I/O pin to low level.
 */
 static __forceinline void     PIN_SWDIO_TMS_CLR (void) {
-    LPC_GPIO->CLR[0] = (PIN_SWDIO);
+	LPC_GPIO->CLR[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
 }
 
 /** SWDIO I/O pin: Get Input (used in SWD mode only).
 \return Current status of the SWDIO DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_SWDIO_IN      (void) {
-    return LPC_GPIO->B[PIN_SWDIO_IN_BIT] & 0x1;
+  return (LPC_GPIO->B[SWDIO_TMS_PIN]);
 }
 
 /** SWDIO I/O pin: Set Output (used in SWD mode only).
 \param bit Output value for the SWDIO DAP hardware I/O pin.
 */
-static __forceinline void     PIN_SWDIO_OUT     (uint32_t bit){
-    if (bit & 0x1)
-        LPC_GPIO->SET[0] = (PIN_SWDIO);
-    else
-        LPC_GPIO->CLR[0] = (PIN_SWDIO);
+static __forceinline void     PIN_SWDIO_OUT     (uint32_t bit) {
+	if (bit & 1)
+		LPC_GPIO->SET[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
+	else
+		LPC_GPIO->CLR[SWDIO_TMS_PORT] = (1 << SWDIO_TMS_PIN);
 }
 
 /** SWDIO I/O pin: Switch to Output mode (used in SWD mode only).
@@ -303,7 +275,8 @@ Configure the SWDIO DAP hardware I/O pin to output mode. This function is
 called prior \ref PIN_SWDIO_OUT function calls.
 */
 static __forceinline void     PIN_SWDIO_OUT_ENABLE  (void) {
-    LPC_GPIO->DIR[0]  |= (PIN_SWDIO);
+	LPC_GPIO->SET[SWDIO_TMS_DIRCTRL_PORT] = (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] |= (1 << SWDIO_TMS_PORT);
 }
 
 /** SWDIO I/O pin: Switch to Input mode (used in SWD mode only).
@@ -311,7 +284,8 @@ Configure the SWDIO DAP hardware I/O pin to input mode. This function is
 called prior \ref PIN_SWDIO_IN function calls.
 */
 static __forceinline void     PIN_SWDIO_OUT_DISABLE (void) {
-    LPC_GPIO->DIR[0]  &= ~(PIN_SWDIO);
+	LPC_GPIO->CLR[SWDIO_TMS_DIRCTRL_PORT] = (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] &= ~(1 << SWDIO_TMS_PORT);
 }
 
 
@@ -321,25 +295,17 @@ static __forceinline void     PIN_SWDIO_OUT_DISABLE (void) {
 \return Current status of the TDI DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_TDI_IN  (void) {
-#if (DAP_JTAG != 0)
-    return LPC_GPIO->B[PIN_TDI_IN_BIT] & 0x1;
-#else
-  return (0);   // Not available
-#endif
+ return (LPC_GPIO->B[TDI_PIN]);
 }
 
 /** TDI I/O pin: Set Output.
 \param bit Output value for the TDI DAP hardware I/O pin.
 */
 static __forceinline void     PIN_TDI_OUT (uint32_t bit) {
-#if (DAP_JTAG != 0)
-    if (bit & 0x1)
-        LPC_GPIO->SET[0] = (PIN_TDI);
-    else
-        LPC_GPIO->CLR[0] = (PIN_TDI);
-#else
-  ;             // Not available
-#endif
+	if (bit & 1)
+		LPC_GPIO->SET[TDI_PORT] = (1 << TDI_PIN);
+	else
+		LPC_GPIO->CLR[TDI_PORT] = (1 << TDI_PIN);
 }
 
 
@@ -349,11 +315,7 @@ static __forceinline void     PIN_TDI_OUT (uint32_t bit) {
 \return Current status of the TDO DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_TDO_IN  (void) {
-#if (DAP_JTAG != 0)
-    return LPC_GPIO->B[PIN_TDO_IN_BIT] & 0x1;
-#else
-  return (0);   // Not available
-#endif
+  return (LPC_GPIO->B[SWO_TDO_PIN]);
 }
 
 
@@ -363,7 +325,7 @@ static __forceinline uint32_t PIN_TDO_IN  (void) {
 \return Current status of the nTRST DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_nTRST_IN   (void) {
-  return (0);   // Not available
+  return (LPC_GPIO->B[TRST_PIN]);
 }
 
 /** nTRST I/O pin: Set Output.
@@ -372,7 +334,10 @@ static __forceinline uint32_t PIN_nTRST_IN   (void) {
            - 1: release JTAG TRST Test Reset.
 */
 static __forceinline void     PIN_nTRST_OUT  (uint32_t bit) {
-  ;             // Not available
+	if (bit & 1)
+		LPC_GPIO->SET[TRST_PORT] = (1 << TRST_PIN);
+	else
+		LPC_GPIO->CLR[TRST_PORT] = (1 << TRST_PIN);
 }
 
 // nRESET Pin I/O------------------------------------------
@@ -381,7 +346,7 @@ static __forceinline void     PIN_nTRST_OUT  (uint32_t bit) {
 \return Current status of the nRESET DAP hardware I/O pin.
 */
 static __forceinline uint32_t PIN_nRESET_IN  (void) {
-    return LPC_GPIO->B[PIN_nRESET_IN_BIT] & 0x1;
+  return (LPC_GPIO->B[RESET_PIN]);
 }
 
 /** nRESET I/O pin: Set Output.
@@ -390,23 +355,17 @@ static __forceinline uint32_t PIN_nRESET_IN  (void) {
            - 1: release device hardware reset.
 */
 static __forceinline void     PIN_nRESET_OUT (uint32_t bit) {
-#if defined(CONF_OPENDRAIN)
-    // open drain logic
-    if (bit) LPC_GPIO->DIR[0] &= ~PIN_nRESET; // input (pulled high external)
-    else     LPC_GPIO->DIR[0] |=  PIN_nRESET; // output (low)
-#else
-    if (bit)
-        LPC_GPIO->SET[0] = (PIN_nRESET);
-    else
-        LPC_GPIO->CLR[0] = (PIN_nRESET);
-#endif
+	if (bit & 1)
+		LPC_GPIO->SET[RESET_PORT] = (1 << RESET_PIN);
+	else
+		LPC_GPIO->CLR[RESET_PORT] = (1 << RESET_PIN);
 }
 
 ///@}
 
 
 //**************************************************************************************************
-/**
+/** 
 \defgroup DAP_Config_LEDs_gr CMSIS-DAP Hardware Status LEDs
 \ingroup DAP_ConfigIO_gr
 @{
@@ -424,6 +383,10 @@ It is recommended to provide the following LEDs for status indication:
            - 0: Connect LED OFF: debugger is not connected to CMSIS-DAP Debug Unit.
 */
 static __inline void LED_CONNECTED_OUT (uint32_t bit) {
+	if (bit & 1)
+		LPC_GPIO->SET[LED_CON_PORT] = (1 << LED_CON_PIN);
+	else
+		LPC_GPIO->CLR[LED_CON_PORT] = (1 << LED_CON_PIN);
 }
 
 /** Debug Unit: Set status Target Running LED.
@@ -432,14 +395,17 @@ static __inline void LED_CONNECTED_OUT (uint32_t bit) {
            - 0: Target Running LED OFF: program execution in target stopped.
 */
 static __inline void LED_RUNNING_OUT (uint32_t bit) {
-  ;             // Not available
+	if (bit & 1)
+		LPC_GPIO->SET[LED_RUN_PORT] = (1 << LED_RUN_PIN);
+	else
+		LPC_GPIO->CLR[LED_RUN_PORT] = (1 << LED_RUN_PIN);
 }
 
 ///@}
 
 
 //**************************************************************************************************
-/**
+/** 
 \defgroup DAP_Config_Initialization_gr CMSIS-DAP Initialization
 \ingroup DAP_ConfigIO_gr
 @{
@@ -448,31 +414,38 @@ CMSIS-DAP Hardware I/O and LED Pins are initialized with the function \ref DAP_S
 */
 
 /** Setup of the Debug Unit I/O pins and LEDs (called when Debug Unit is initialized).
-This function performs the initialization of the CMSIS-DAP Hardware I/O Pins and the
+This function performs the initialization of the CMSIS-DAP Hardware I/O Pins and the 
 Status LEDs. In detail the operation of Hardware I/O and LED pins are enabled and set:
  - I/O clock system enabled.
  - all I/O pins: input buffer enabled, output pins are set to HighZ mode.
  - for nTRST, nRESET a weak pull-up (if available) is enabled.
  - LED output pins are enabled and LEDs are turned off.
 */
+#define FUNC0		0
+#define FUNC1		1
+#define FUNC2		2
+#define RES_PULLUP		(2 << 3)
+#define RES_PULLDOWN	(1 << 3)
 static __inline void DAP_SETUP (void) {
-    // Configure I/O pins
-	PIN_SWCLK_TCK_IOCON = FUNC_0 | PULL_UP_ENABLED;  // SWCLK/TCK
-	PIN_SWDIO_TMS_IOCON = FUNC_0 | PULL_UP_ENABLED;  // SWDIO/TMS
-#if !defined(CONF_OPENDRAIN)
-	PIN_nRESET_IOCON    = FUNC_0 | PULL_UP_ENABLED;  // nRESET
-#else
-	PIN_nRESET_IOCON    = FUNC_0 | OPENDRAIN;        // nRESET
-#endif
-#if (DAP_JTAG != 0)
-	PIN_TDI_IOCON       = FUNC_0 | PULL_UP_ENABLED;  // TDI
-	PIN_TDO_IOCON       = FUNC_0 | PULL_UP_ENABLED;  // TDO
-#endif
+	LPC_IOCON->TMS_PIO0_12 = FUNC1 | RES_PULLUP | 0x80;		// SWDIO_TMS_DIRCTRL
+	LPC_GPIO->DIR[SWDIO_TMS_DIRCTRL_PORT] |= (1 << SWDIO_TMS_DIRCTRL_PIN);
+	LPC_IOCON->TDO_PIO0_13 = FUNC1 | RES_PULLUP | 0x80;		// SWDIO_TMS
+	LPC_GPIO->DIR[SWDIO_TMS_PORT] |= (1 << SWDIO_TMS_PIN);
+	LPC_IOCON->TRST_PIO0_14 = FUNC1 | RES_PULLUP | 0x80;	// SWCLK_TCK
+	LPC_GPIO->DIR[SWCLK_TCK_PORT] |= (1 << SWCLK_TCK_PIN);
+	LPC_IOCON->PIO1_19 = FUNC0 | RES_PULLUP;				// RESET
+	LPC_GPIO->DIR[RESET_PORT] |= (1 << RESET_PIN);
+	LPC_IOCON->PIO0_16 = FUNC0 | RES_PULLUP;				// TDI
+	LPC_IOCON->PIO0_23 = FUNC0 | RES_PULLUP;				// SWO_TDO
+	LPC_IOCON->PIO0_22 = FUNC0 | RES_PULLUP;				// TRST
+	LPC_IOCON->TDI_PIO0_11 = FUNC2;								// VCCSENSE Analog in
+	LPC_IOCON->PIO0_17 = FUNC0;								// LED_CON
+	LPC_IOCON->PIO1_15 = FUNC0;								// LED_RUN
 }
 
 /** Reset Target Device with custom specific I/O pin or command sequence.
 This function allows the optional implementation of a device specific reset sequence.
-It is called when the command \ref DAP_ResetTarget and is for example required
+It is called when the command \ref DAP_ResetTarget and is for example required 
 when a device needs a time-critical unlock sequence that enables the debug port.
 \return 0 = no device specific reset sequence is implemented.\n
         1 = a device specific reset sequence is implemented.

--- a/interface/mdk/lpc11u35/lpc11u35_interface.uvproj
+++ b/interface/mdk/lpc11u35/lpc11u35_interface.uvproj
@@ -72,6 +72,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -128,6 +130,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -139,9 +142,10 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
-          <TargetSelection>8</TargetSelection>
+          <TargetSelection>7</TargetSelection>
           <SimDlls>
             <CpuDll></CpuDll>
             <CpuDllArguments></CpuDllArguments>
@@ -353,6 +357,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC812, BOARD_LPC812_MAX</Define>
@@ -369,6 +375,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -385,6 +392,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -504,6 +512,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -615,6 +625,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -631,6 +643,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -681,11 +694,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -741,6 +749,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -782,6 +795,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -833,6 +848,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -913,6 +930,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -969,6 +988,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -980,6 +1000,7 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
           <TargetSelection>8</TargetSelection>
@@ -1194,6 +1215,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC812, BOARD_LPC812_MAX</Define>
@@ -1210,6 +1233,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>NO_CRP</Define>
@@ -1226,6 +1250,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35_mbed_bootloader.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -1345,6 +1370,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -1456,6 +1483,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1472,6 +1501,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1522,11 +1552,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -1582,6 +1607,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1623,6 +1653,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -1674,6 +1706,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -1754,6 +1788,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -1810,6 +1846,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -1821,6 +1858,7 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
           <TargetSelection>1</TargetSelection>
@@ -2035,6 +2073,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC1114, BOARD_LPC1114</Define>
@@ -2051,6 +2091,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -2067,6 +2108,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -2186,6 +2228,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -2292,6 +2336,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -2338,6 +2384,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -2354,6 +2402,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -2404,11 +2453,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -2464,6 +2508,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2505,6 +2554,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -2535,13 +2586,13 @@
       <ToolsetName>ARM-ADS</ToolsetName>
       <TargetOption>
         <TargetCommonOption>
-          <Device>LPC11U35/401</Device>
-          <Vendor>NXP (founded by Philips)</Vendor>
+          <Device>LPC11U35/501</Device>
+          <Vendor>NXP</Vendor>
           <Cpu>IRAM(0x10000000-0x10001FFF) IRAM2(0x20004000-0x200047FF) IROM(0-0xFFFF) CLOCK(12000000) CPUTYPE("Cortex-M0")</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile>"STARTUP\NXP\LPC11Uxx\startup_LPC11Uxx.s" ("NXP LPC11Uxx Startup Code")</StartupFile>
           <FlashDriverDll>UL2CM3(-O4303 -S0 -C0 -FO7 -FD10000000 -FC800 -FN1 -FF0LPC1xxx_64 -FS00 -FL010000)</FlashDriverDll>
-          <DeviceId>6505</DeviceId>
+          <DeviceId>6506</DeviceId>
           <RegisterFile>LPC11Uxx.h</RegisterFile>
           <MemoryEnv></MemoryEnv>
           <Cmp></Cmp>
@@ -2595,6 +2646,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -2651,6 +2704,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -2662,9 +2716,10 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
-          <TargetSelection>8</TargetSelection>
+          <TargetSelection>6</TargetSelection>
           <SimDlls>
             <CpuDll></CpuDll>
             <CpuDllArguments></CpuDllArguments>
@@ -2678,7 +2733,7 @@
             <PeripheralDll></PeripheralDll>
             <PeripheralDllArguments></PeripheralDllArguments>
             <InitializationFile></InitializationFile>
-            <Driver>BIN\ULP2CM3.DLL</Driver>
+            <Driver>Segger\JL2CM3.dll</Driver>
           </TargetDlls>
         </DebugOption>
         <Utilities>
@@ -2688,11 +2743,11 @@
             <RunIndependent>0</RunIndependent>
             <UpdateFlashBeforeDebugging>1</UpdateFlashBeforeDebugging>
             <Capability>1</Capability>
-            <DriverSelection>4101</DriverSelection>
+            <DriverSelection>4100</DriverSelection>
           </Flash1>
           <bUseTDR>1</bUseTDR>
-          <Flash2>BIN\ULP2CM3.DLL</Flash2>
-          <Flash3>"" ()</Flash3>
+          <Flash2>BIN\UL2CM3.DLL</Flash2>
+          <Flash3></Flash3>
           <Flash4></Flash4>
           <pFcarmOut></pFcarmOut>
           <pFcarmGrp></pFcarmGrp>
@@ -2856,7 +2911,7 @@
               </OCR_RVCT9>
               <OCR_RVCT10>
                 <Type>0</Type>
-                <StartAddress>0x20000000</StartAddress>
+                <StartAddress>0x20004000</StartAddress>
                 <Size>0x800</Size>
               </OCR_RVCT10>
             </OnChipMemories>
@@ -2864,8 +2919,8 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>3</Optim>
-            <oTime>1</oTime>
+            <Optim>4</Optim>
+            <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>0</OneElfS>
             <Strict>0</Strict>
@@ -2876,6 +2931,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC1114, BOARD_LPC1114</Define>
@@ -2892,6 +2949,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>NO_CRP</Define>
@@ -2908,6 +2966,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35_mbed_bootloader.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -3027,6 +3086,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -3133,6 +3194,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -3179,6 +3242,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -3195,6 +3260,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -3245,11 +3311,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -3305,6 +3366,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3346,6 +3412,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -3436,6 +3504,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -3492,6 +3562,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -3503,9 +3574,10 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
-          <TargetSelection>8</TargetSelection>
+          <TargetSelection>7</TargetSelection>
           <SimDlls>
             <CpuDll></CpuDll>
             <CpuDllArguments></CpuDllArguments>
@@ -3717,6 +3789,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC1768, BOARD_SEEED_ARCH_PRO</Define>
@@ -3733,6 +3807,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -3749,6 +3824,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -3868,6 +3944,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -3974,6 +4052,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -4020,6 +4100,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -4036,6 +4118,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -4086,11 +4169,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -4146,6 +4224,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -4197,6 +4280,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -4217,13 +4302,13 @@
       <ToolsetName>ARM-ADS</ToolsetName>
       <TargetOption>
         <TargetCommonOption>
-          <Device>LPC11U35/401</Device>
-          <Vendor>NXP (founded by Philips)</Vendor>
+          <Device>LPC11U35/501</Device>
+          <Vendor>NXP</Vendor>
           <Cpu>IRAM(0x10000000-0x10001FFF) IRAM2(0x20004000-0x200047FF) IROM(0-0xFFFF) CLOCK(12000000) CPUTYPE("Cortex-M0")</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile>"STARTUP\NXP\LPC11Uxx\startup_LPC11Uxx.s" ("NXP LPC11Uxx Startup Code")</StartupFile>
           <FlashDriverDll>UL2CM3(-O4303 -S0 -C0 -FO7 -FD10000000 -FC800 -FN1 -FF0LPC1xxx_64 -FS00 -FL010000)</FlashDriverDll>
-          <DeviceId>6505</DeviceId>
+          <DeviceId>6506</DeviceId>
           <RegisterFile>LPC11Uxx.h</RegisterFile>
           <MemoryEnv></MemoryEnv>
           <Cmp></Cmp>
@@ -4277,6 +4362,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -4333,6 +4420,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -4344,9 +4432,10 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
-          <TargetSelection>8</TargetSelection>
+          <TargetSelection>6</TargetSelection>
           <SimDlls>
             <CpuDll></CpuDll>
             <CpuDllArguments></CpuDllArguments>
@@ -4360,7 +4449,7 @@
             <PeripheralDll></PeripheralDll>
             <PeripheralDllArguments></PeripheralDllArguments>
             <InitializationFile></InitializationFile>
-            <Driver>BIN\ULP2CM3.DLL</Driver>
+            <Driver>Segger\JL2CM3.dll</Driver>
           </TargetDlls>
         </DebugOption>
         <Utilities>
@@ -4373,8 +4462,8 @@
             <DriverSelection>4101</DriverSelection>
           </Flash1>
           <bUseTDR>1</bUseTDR>
-          <Flash2>BIN\ULP2CM3.DLL</Flash2>
-          <Flash3>"" ()</Flash3>
+          <Flash2>BIN\UL2CM3.DLL</Flash2>
+          <Flash3></Flash3>
           <Flash4></Flash4>
           <pFcarmOut></pFcarmOut>
           <pFcarmGrp></pFcarmGrp>
@@ -4538,7 +4627,7 @@
               </OCR_RVCT9>
               <OCR_RVCT10>
                 <Type>0</Type>
-                <StartAddress>0x20000000</StartAddress>
+                <StartAddress>0x20004000</StartAddress>
                 <Size>0x800</Size>
               </OCR_RVCT10>
             </OnChipMemories>
@@ -4546,8 +4635,8 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>3</Optim>
-            <oTime>1</oTime>
+            <Optim>4</Optim>
+            <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>0</OneElfS>
             <Strict>0</Strict>
@@ -4558,6 +4647,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC1768, BOARD_SEEED_ARCH_PRO</Define>
@@ -4574,6 +4665,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>NO_CRP</Define>
@@ -4590,6 +4682,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35_mbed_bootloader.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -4709,6 +4802,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -4815,6 +4910,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -4861,6 +4958,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -4877,6 +4976,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -4927,11 +5027,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -4987,6 +5082,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -5038,6 +5138,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -5118,6 +5220,8 @@
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
+            <nStopB1X>0</nStopB1X>
+            <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
@@ -5174,6 +5278,7 @@
             <RestoreFunctions>1</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <LimitSpeedToRealTime>0</LimitSpeedToRealTime>
+            <RestoreSysVw>1</RestoreSysVw>
           </Simulator>
           <Target>
             <UseTarget>1</UseTarget>
@@ -5185,6 +5290,7 @@
             <RestoreFunctions>0</RestoreFunctions>
             <RestoreToolbox>1</RestoreToolbox>
             <RestoreTracepoints>0</RestoreTracepoints>
+            <RestoreSysVw>1</RestoreSysVw>
           </Target>
           <RunDebugAfterBuild>0</RunDebugAfterBuild>
           <TargetSelection>8</TargetSelection>
@@ -5399,6 +5505,8 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
+            <uC99>0</uC99>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define>TARGET_LPC11U35, __RTX, DBG_LPC1768, BOARD_UBLOX_C027</Define>
@@ -5415,6 +5523,7 @@
             <SwStkChk>0</SwStkChk>
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
+            <useXO>0</useXO>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -5431,6 +5540,7 @@
             <useFile>0</useFile>
             <TextAddressRange>0x00000000</TextAddressRange>
             <DataAddressRange>0x1FFFE000</DataAddressRange>
+            <pXoBase></pXoBase>
             <ScatterFile>..\..\..\shared\cmsis\TARGET_NXP\TARGET_LPC11UXX\TOOLCHAIN_ARM_STD\LPC11U35.sct</ScatterFile>
             <IncludeLibs></IncludeLibs>
             <IncludeLibsPath></IncludeLibsPath>
@@ -5550,6 +5660,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls>--c99</MiscControls>
                       <Define></Define>
@@ -5656,6 +5768,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>
@@ -5702,6 +5816,8 @@
                 <wLevel>0</wLevel>
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -5718,6 +5834,7 @@
                 <SwStkChk>2</SwStkChk>
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -5768,11 +5885,6 @@
         <Group>
           <GroupName>RTX</GroupName>
           <Files>
-            <File>
-              <FileName>HAL_CM1.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\shared\rtos\HAL_CM1.c</FilePath>
-            </File>
             <File>
               <FileName>rt_Event.c</FileName>
               <FileType>1</FileType>
@@ -5828,6 +5940,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\shared\rtos\rt_Timer.c</FilePath>
             </File>
+            <File>
+              <FileName>HAL_CM0.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\shared\rtos\HAL_CM0.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -5879,6 +5996,8 @@
                     <wLevel>0</wLevel>
                     <uThumb>2</uThumb>
                     <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <useXO>2</useXO>
                     <VariousControls>
                       <MiscControls></MiscControls>
                       <Define></Define>

--- a/shared/rtos/HAL_CM0.c
+++ b/shared/rtos/HAL_CM0.c
@@ -1,0 +1,345 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    HAL_CM0.C
+ *      Purpose: Hardware Abstraction Layer for Cortex-M0
+ *      Rev.:    V4.70
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+#include "rt_TypeDef.h"
+#include "RTX_Config.h"
+#include "rt_System.h"
+#include "rt_HAL_CM.h"
+#include "rt_Task.h"
+#include "rt_MemBox.h"
+
+
+/*----------------------------------------------------------------------------
+ *      Functions
+ *---------------------------------------------------------------------------*/
+
+
+/*--------------------------- rt_set_PSP ------------------------------------*/
+
+__asm void rt_set_PSP (U32 stack) {
+        MSR     PSP,R0
+        BX      LR
+}
+
+
+/*--------------------------- rt_get_PSP ------------------------------------*/
+
+__asm U32 rt_get_PSP (void) {
+        MRS     R0,PSP
+        BX      LR
+}
+
+
+/*--------------------------- os_set_env ------------------------------------*/
+
+__asm void os_set_env (void) {
+   /* Switch to Unprivileged/Privileged Thread mode, use PSP. */
+        MOV     R0,SP                   ; PSP = MSP
+        MSR     PSP,R0
+        LDR     R0,=__cpp(&os_flags)
+        LDRB    R0,[R0]
+        LSLS    R0,#31
+        BNE     PrivilegedE
+        MOVS    R0,#0x03                ; Unprivileged Thread mode, use PSP
+        MSR     CONTROL,R0
+        BX      LR
+PrivilegedE
+        MOVS    R0,#0x02                ; Privileged Thread mode, use PSP
+        MSR     CONTROL,R0
+        BX      LR
+
+        ALIGN
+}
+
+
+/*--------------------------- _alloc_box ------------------------------------*/
+
+__asm void *_alloc_box (void *box_mem) {
+   /* Function wrapper for Unprivileged/Privileged mode. */
+        LDR     R3,=__cpp(rt_alloc_box)
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedA
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedA
+        SVC     0
+        BX      LR
+PrivilegedA
+        BX      R12
+
+        ALIGN
+}
+
+
+/*--------------------------- _free_box -------------------------------------*/
+
+__asm int _free_box (void *box_mem, void *box) {
+   /* Function wrapper for Unprivileged/Privileged mode. */
+        LDR     R3,=__cpp(rt_free_box)
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedF
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedF
+        SVC     0
+        BX      LR
+PrivilegedF
+        BX      R12
+
+        ALIGN
+}
+
+
+/*-------------------------- SVC_Handler ------------------------------------*/
+
+__asm void SVC_Handler (void) {
+        PRESERVE8
+
+        IMPORT  SVC_Count
+        IMPORT  SVC_Table
+        IMPORT  rt_stk_check
+
+        MRS     R0,PSP                  ; Read PSP
+        LDR     R1,[R0,#24]             ; Read Saved PC from Stack
+        SUBS    R1,R1,#2                ; Point to SVC Instruction
+        LDRB    R1,[R1]                 ; Load SVC Number
+        CMP     R1,#0
+        BNE     SVC_User                ; User SVC Number > 0
+
+        MOV     LR,R4
+        LDMIA   R0,{R0-R3,R4}           ; Read R0-R3,R12 from stack
+        MOV     R12,R4
+        MOV     R4,LR
+        BLX     R12                     ; Call SVC Function 
+
+        MRS     R3,PSP                  ; Read PSP
+        STMIA   R3!,{R0-R2}             ; Store return values
+
+        LDR     R3,=__cpp(&os_tsk)
+        LDMIA   R3!,{R1,R2}             ; os_tsk.run, os_tsk.new
+        CMP     R1,R2
+        BEQ     SVC_Exit                ; no task switch
+
+        SUBS    R3,#8
+        CMP     R1,#0                   ; Runtask deleted?
+        BEQ     SVC_Next
+
+        MRS     R0,PSP                  ; Read PSP
+        SUBS    R0,R0,#32               ; Adjust Start Address
+        STR     R0,[R1,#TCB_TSTACK]     ; Update os_tsk.run->tsk_stack       
+        STMIA   R0!,{R4-R7}             ; Save old context (R4-R7)
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             ; Save old context (R8-R11)
+        
+        PUSH    {R2,R3}
+        BL      rt_stk_check            ; Check for Stack overflow
+        POP     {R2,R3}
+
+SVC_Next
+        STR     R2,[R3]                 ; os_tsk.run = os_tsk.new
+
+        LDR     R0,[R2,#TCB_TSTACK]     ; os_tsk.new->tsk_stack
+        ADDS    R0,R0,#16               ; Adjust Start Address
+        LDMIA   R0!,{R4-R7}             ; Restore new Context (R8-R11)
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  ; Write PSP
+        SUBS    R0,R0,#32               ; Adjust Start Address
+        LDMIA   R0!,{R4-R7}             ; Restore new Context (R4-R7)
+
+SVC_Exit
+        MOVS    R0,#:NOT:0xFFFFFFFD     ; Set EXC_RETURN value
+        MVNS    R0,R0
+        BX      R0                      ; RETI to Thread Mode, use PSP
+
+        /*------------------- User SVC ------------------------------*/
+
+SVC_User
+        PUSH    {R4,LR}                 ; Save Registers
+        LDR     R2,=SVC_Count
+        LDR     R2,[R2]
+        CMP     R1,R2
+        BHI     SVC_Done                ; Overflow
+
+        LDR     R4,=SVC_Table-4
+        LSLS    R1,R1,#2
+        LDR     R4,[R4,R1]              ; Load SVC Function Address
+        MOV     LR,R4
+
+        LDMIA   R0,{R0-R3,R4}           ; Read R0-R3,R12 from stack
+        MOV     R12,R4
+        BLX     LR                      ; Call SVC Function
+
+        MRS     R4,PSP                  ; Read PSP
+        STMIA   R4!,{R0-R3}             ; Function return values
+SVC_Done
+        POP     {R4,PC}                 ; RETI
+
+        ALIGN
+}
+
+
+/*-------------------------- PendSV_Handler ---------------------------------*/
+
+__asm void PendSV_Handler (void) {
+        PRESERVE8
+
+        BL      __cpp(rt_pop_req)
+
+Sys_Switch
+        LDR     R3,=__cpp(&os_tsk)
+        LDMIA   R3!,{R1,R2}             ; os_tsk.run, os_tsk.new
+        CMP     R1,R2
+        BEQ     Sys_Exit                ; no task switch
+
+        SUBS    R3,#8
+
+        MRS     R0,PSP                  ; Read PSP
+        SUBS    R0,R0,#32               ; Adjust Start Address
+        STR     R0,[R1,#TCB_TSTACK]     ; Update os_tsk.run->tsk_stack
+        STMIA   R0!,{R4-R7}             ; Save old context (R4-R7)
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             ; Save old context (R8-R11)
+        
+        PUSH    {R2,R3}
+        BL      rt_stk_check            ; Check for Stack overflow
+        POP     {R2,R3}
+
+        STR     R2,[R3]                 ; os_tsk.run = os_tsk.new
+
+        LDR     R0,[R2,#TCB_TSTACK]     ; os_tsk.new->tsk_stack
+        ADDS    R0,R0,#16               ; Adjust Start Address
+        LDMIA   R0!,{R4-R7}             ; Restore new Context (R8-R11)
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  ; Write PSP
+        SUBS    R0,R0,#32               ; Adjust Start Address
+        LDMIA   R0!,{R4-R7}             ; Restore new Context (R4-R7)
+
+Sys_Exit
+        MOVS    R0,#:NOT:0xFFFFFFFD     ; Set EXC_RETURN value
+        MVNS    R0,R0
+        BX      R0                      ; RETI to Thread Mode, use PSP
+
+        ALIGN
+}
+
+
+/*-------------------------- SysTick_Handler --------------------------------*/
+
+__asm void SysTick_Handler (void) {
+        PRESERVE8
+
+        BL      __cpp(rt_systick)
+        B       Sys_Switch
+
+        ALIGN
+}
+
+
+/*-------------------------- OS_Tick_Handler --------------------------------*/
+
+__asm void OS_Tick_Handler (void) {
+        PRESERVE8
+
+        BL      __cpp(os_tick_irqack)
+        BL      __cpp(rt_systick)
+        B       Sys_Switch
+
+        ALIGN
+}
+/*--------------------------- rt_init_stack ---------------------------------*/
+
+void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
+  /* Prepare TCB and saved context for a first time start of a task. */
+  U32 *stk,i,size;
+
+  /* Prepare a complete interrupt frame for first task start */
+  size = p_TCB->priv_stack >> 2;
+  if (size == 0) {
+    size = (U16)os_stackinfo >> 2;
+  }
+
+  /* Write to the top of stack. */
+  stk = &p_TCB->stack[size];
+
+  /* Auto correct to 8-byte ARM stack alignment. */
+  if ((U32)stk & 0x04) {
+    stk--;
+  }
+
+  stk -= 16;
+
+  /* Default xPSR and initial PC */
+  stk[15] = INITIAL_xPSR;
+  stk[14] = (U32)task_body;
+
+  /* Clear R1-R12,LR registers. */
+  for (i = 0; i < 14; i++) {
+    stk[i] = 0;
+  }
+
+  /* Assign a void pointer to R0. */
+  stk[8] = (U32)p_TCB->msg;
+
+  /* Initial Task stack pointer. */
+  p_TCB->tsk_stack = (U32)stk;
+
+  /* Task entry point. */
+  p_TCB->ptask = task_body;
+
+  /* Set a magic word for checking of stack overflow. */
+  p_TCB->stack[0] = MAGIC_WORD;
+}
+
+
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/
+


### PR DESCRIPTION
I developed interface firmware for nRF52 DK using Keil MDK and copied to CRP DISABLD drive then I am trying to drop ".bin" (blinky) example in MBED drive, It was asserting an error "RESERVED BITS" in "fail.txt".

Please feel free to go through the modified "target_reset.h"
![target_flash](https://user-images.githubusercontent.com/28245520/27649784-d0524ea8-5c00-11e7-89a3-674a658ed485.PNG)

Please help me regarding this and looking forward to it.



